### PR TITLE
Use Full Dart Format Command

### DIFF
--- a/run
+++ b/run
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-dartfmt --write $@
+dart format --output write --set-exit-if-changed $@


### PR DESCRIPTION
Allows usage of hook with Flutter projects, which usually only include the `dart` binary